### PR TITLE
Workflow modifications to support automated global execution

### DIFF
--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -385,6 +385,7 @@
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
+                "temporal_range.$": "$.temporal_range",
                 "counter.$": "$.counter",
                 "version.$": "$.version"
             },
@@ -410,6 +411,8 @@
                                 "Command": [
                                     "-i",
                                     "Ref::index",
+                                    "-t",
+                                    "Ref::temporal_range",
                                     "-r",
                                     "/mnt/data/expanded_reaches_of_interest.json",
                                     "-o",
@@ -423,6 +426,7 @@
                             "JobName.$": "States.Format('confluence-input-subset-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                             "Parameters": {
                                 "index.$": "States.Format('{}',$.context_index)",
+                                "temporal_range.$": "$.temporal_range",
                                 "prefix": "${prefix}"
                             }
                         },
@@ -489,6 +493,7 @@
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
+                "temporal_range.$": "$.temporal_range",
                 "counter.$": "$.counter",
                 "version.$": "$.version"
             },
@@ -514,6 +519,8 @@
                                 "Command": [
                                     "-i",
                                     "Ref::index",
+                                    "-t",
+                                    "Ref::temporal_range",
                                     "-r",
                                     "/mnt/data/reaches.json",
                                     "-o",
@@ -527,6 +534,7 @@
                             "JobName.$": "States.Format('confluence-input-global-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                             "Parameters": {
                                 "index.$": "States.Format('{}',$.context_index)",
+                                "temporal_range.$": "$.temporal_range",
                                 "prefix": "${prefix}"
                             }
                         },

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -693,7 +693,7 @@
                 }
             },
             "Label": "prediagnostics",
-            "Next": "Priors",
+            "Next": "Priors Choice",
             "Catch": [
                 {
                     "ErrorEquals": [
@@ -704,7 +704,104 @@
                 }
             ]
         },
+        "Priors Choice": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.run_gbpriors",
+                    "IsPresent": false,
+                    "Next": "Priors"
+                },
+                {
+                    "Variable": "$.run_gbpriors",
+                    "IsPresent": true,
+                    "Next": "Priors GBPriors"
+                }
+            ]
+        },
         "Priors": {
+            "Type": "Map",
+            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
+            "ResultPath": null,
+            "ItemSelector": {
+                "context_index.$": "$$.Map.Item.Index",
+                "context_value.$": "$$.Map.Item.Value",
+                "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
+            },
+            "ItemProcessor": {
+                "ProcessorConfig": {
+                    "Mode": "DISTRIBUTED",
+                    "ExecutionType": "STANDARD"
+                },
+                "StartAt": "Batch SubmitJob Priors",
+                "States": {
+                    "Batch SubmitJob Priors": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::batch:submitJob.sync",
+                        "Parameters": {
+                            "JobDefinition": "arn:aws:batch:${aws_region}:${account_id}:job-definition/${prefix}-priors",
+                            "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-priors",
+                            "PropagateTags": true,
+                            "Tags": {
+                                "job.$": "States.Format('confluence-priors-{}-{}-{}-{}', $.run_type, $.version, $.counter, $.context_index)",
+                                "job_definition.$": "States.Format('confluence-priors-{}-{}-{}', $.run_type, $.version, $.counter)"
+                            },
+                            "ContainerOverrides": {
+                                "Command": [
+                                    "-i",
+                                    "Ref::index",
+                                    "-r",
+                                    "Ref::run_type",
+                                    "-p",
+                                    "usgs",
+                                    "riggs",
+                                    "-g",
+                                    "-s",
+                                    "Ref::sos_bucket",
+                                    "-o",
+                                    "Ref::version"
+                                ]
+                            },
+                            "JobName.$": "States.Format('confluence-priors-{}-{}-{}-{}', $.run_type, $.version, $.counter, $.context_index)",
+                            "Parameters": {
+                                "index.$": "States.Format('{}', $.context_index)",
+                                "run_type.$": "States.Format('{}', $.run_type)",
+                                "sos_bucket": "${prefix}-sos",
+                                "version.$": "States.Format('{}', $.version)"
+                            }
+                        },
+                        "End": true,
+                        "TimeoutSeconds": 108000,
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "States.Timeout"
+                                ],
+                                "BackoffRate": 2,
+                                "IntervalSeconds": 1,
+                                "MaxAttempts": 3,
+                                "JitterStrategy": "FULL"
+                            }
+                        ]
+                    }
+                }
+            },
+            "ItemReader": {
+                "Resource": "arn:aws:states:::s3:getObject",
+                "ReaderConfig": {
+                    "InputType": "JSON"
+                },
+                "Parameters": {
+                    "Bucket": "${prefix}-json",
+                    "Key": "continent.json"
+                }
+            },
+            "Label": "priors",
+            "Next": "Hivdi"
+        },
+        "Priors GBPriors": {
             "Type": "Map",
             "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -639,13 +639,18 @@
                             },
                             "ContainerOverrides": {
                                 "Command": [
+                                    "-i",
                                     "Ref::index",
+                                    "-b",
+                                    "Ref::config_bucket",
+                                    "-r",
                                     "reaches.json"
                                 ]
                             },
                             "JobName.$": "States.Format('confluence-prediagnostics-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                             "Parameters": {
-                                "index.$": "States.Format('{}',$.context_index)"
+                                "index.$": "States.Format('{}',$.context_index)",
+                                "config_bucket.$": "${prefix}-config/prediagnostics"
                             }
                         },
                         "End": true,

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -74,7 +74,6 @@
         },
         "Setfinder Reach Subset": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
@@ -160,7 +159,6 @@
         },
         "Setfinder Subset Not Expanded": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
@@ -241,7 +239,6 @@
         },
         "Setfinder Global": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
@@ -726,7 +723,6 @@
         },
         "Priors": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
@@ -808,7 +804,6 @@
         },
         "Priors GBPriors": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
@@ -2239,7 +2234,6 @@
         },
         "Output": {
             "Type": "Map",
-            "ToleratedFailurePercentagePath": "$.tolerated_failure_percentage",
             "ResultPath": null,
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -650,7 +650,7 @@
                             "JobName.$": "States.Format('confluence-prediagnostics-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                             "Parameters": {
                                 "index.$": "States.Format('{}',$.context_index)",
-                                "config_bucket.$": "${prefix}-config/prediagnostics"
+                                "config_bucket": "${prefix}-config/prediagnostics"
                             }
                         },
                         "End": true,

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -27,6 +27,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-init-workflow",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-init-workflow-subset-{}-{}', $.version, $.counter)",
                     "job_definition.$": "States.Format('confluence-init-workflow-subset-{}-{}', $.version, $.counter)"
                 },
@@ -56,6 +57,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-init-workflow",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-init-workflow-global-{}-{}', $.version, $.counter)",
                     "job_definition.$": "States.Format('confluence-init-workflow-global-{}-{}', $.version, $.counter)"
                 },
@@ -97,6 +99,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-setfinder",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-setfinder-subset-{}-{}-{}', $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-setfinder-subset-{}-{}', $.version, $.counter)"
                             },
@@ -181,6 +184,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-setfinder",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-setfinder-subset-not-expanded-{}-{}-{}', $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-setfinder-not-expanded-{}-{}', $.version, $.counter)"
                             },
@@ -261,6 +265,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-setfinder",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-setfinder-global-{}-{}-{}', $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-setfinder-global-{}-{}', $.version, $.counter)"
                             },
@@ -328,6 +333,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-combine-data",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-combine-data-subset-{}-{}', $.version, $.counter)",
                     "job_definition.$": "States.Format('confluence-combine-data-subset-{}-{}', $.version, $.counter)"
                 },
@@ -357,6 +363,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-combine-data",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-combine-data-global-{}-{}', $.version, $.counter)",
                     "job_definition.$": "States.Format('confluence-combine-data-global-{}-{}', $.version, $.counter)"
                 },
@@ -401,6 +408,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-input",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-input-subset-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-input-subset-{}-{}', $.version, $.counter)"
                             },
@@ -509,6 +517,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-input",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-input-global-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-input-global-{}-{}', $.version, $.counter)"
                             },
@@ -631,6 +640,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-prediagnostics",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-prediagnostics-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-prediagnostics-{}-{}', $.version, $.counter)"
                             },
@@ -746,6 +756,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-priors",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-priors-{}-{}-{}-{}', $.run_type, $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-priors-{}-{}-{}', $.run_type, $.version, $.counter)"
                             },
@@ -827,6 +838,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-priors",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-priors-{}-{}-{}-{}', $.run_type, $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-priors-{}-{}-{}', $.run_type, $.version, $.counter)"
                             },
@@ -909,6 +921,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-hivdi-{}-{}-{}', $.version, $.counter, $.context_value[0].reach_id)",
                                 "job_definition.$": "States.Format('confluence-hivdi-{}-{}', $.version, $.counter)"
                             },
@@ -1007,6 +1020,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-metroman-{}-{}-{}', $.version, $.counter, $.context_value[0].reach_id)",
                                 "job_definition.$": "States.Format('confluence-metroman-{}-{}', $.version, $.counter)"
                             },
@@ -1124,6 +1138,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-momma-constrained-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-momma-constrained-{}-{}', $.version, $.counter)"
                             },
@@ -1228,6 +1243,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-momma-unconstrained-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-momma-unconstrained-{}-{}', $.version, $.counter)"
                             },
@@ -1331,6 +1347,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-neobam-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-neobam-{}-{}', $.version, $.counter)"
                             },
@@ -1432,6 +1449,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-sad-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-sad-{}-{}', $.version, $.counter)"
                             },
@@ -1533,6 +1551,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-sic4dvar-{}-{}-{}', $.version, $.counter, $.context_value[0].reach_id)",
                                 "job_definition.$": "States.Format('confluence-sic4dvar-{}-{}', $.version, $.counter)"
                             },
@@ -1634,6 +1653,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-metroman-consolidation-{}-{}-{}', $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-metroman-consolidation-{}-{}', $.version, $.counter)"
                             },
@@ -1718,6 +1738,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-postdiagnostics-flpe",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-postdiagnostics-flpe-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-postdiagnostics-flpe-{}-{}', $.version, $.counter)"
                             },
@@ -1826,6 +1847,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-moi",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-moi-{}-{}-{}-{}',$.run_type, $.version, $.counter, $.context_value.basin_id)",
                                 "job_definition.$": "States.Format('confluence-moi-{}-{}-{}',$.run_type, $.version, $.counter)"
                             },
@@ -1946,6 +1968,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-postdiagnostics-moi",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-postdiagnostics-moi-{}-{}-{}', $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-postdiagnostics-moi-{}-{}', $.version, $.counter)"
                             },
@@ -2054,6 +2077,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-offline",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-offline-{}-{}-{}-{}', $.run_type, $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-offline-{}-{}-{}', $.run_type, $.version, $.counter)"
                             },
@@ -2154,6 +2178,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-validation",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-validation-{}-{}-{}-{}',$.run_type, $.version, $.counter, $.context_value.reach_id)",
                                 "job_definition.$": "States.Format('confluence-validation-{}-{}-{}',$.run_type, $.version, $.counter)"
                             },
@@ -2257,6 +2282,7 @@
                             "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-output",
                             "PropagateTags": true,
                             "Tags": {
+                                "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                                 "job.$": "States.Format('confluence-output-{}-{}-{}-{}',$.run_type, $.version, $.counter, $.context_index)",
                                 "job_definition.$": "States.Format('confluence-output-{}-{}-{}',$.run_type, $.version, $.counter)"
                             },
@@ -2361,6 +2387,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-restart",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-restart-{}-{}', $.version, $.counter)"
                 },
                 "ContainerOverrides": {
@@ -2396,6 +2423,7 @@
                 "JobQueue": "arn:aws:batch:${aws_region}:${account_id}:job-queue/${prefix}-restart",
                 "PropagateTags": true,
                 "Tags": {
+                    "name.$": "States.Format('confluence-{}-{}-{}', $.run_type, $.version, $.counter)",
                     "job.$": "States.Format('confluence-restart-subset-{}-{}', $.version, $.counter)"
                 },
                 "ContainerOverrides": {

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -82,6 +82,7 @@
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
                 "reach_subset_file.$": "$.reach_subset_file",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -167,6 +168,7 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -248,6 +250,7 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -389,8 +392,9 @@
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
-                "temporal_range.$": "$.temporal_range",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
+                "temporal_range.$": "$.temporal_range",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -498,8 +502,9 @@
             "ItemSelector": {
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
-                "temporal_range.$": "$.temporal_range",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
+                "temporal_range.$": "$.temporal_range",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -623,6 +628,7 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -904,6 +910,7 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -1002,8 +1009,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1120,8 +1127,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1225,8 +1232,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1329,8 +1336,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1431,8 +1438,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1533,8 +1540,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1636,6 +1643,7 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
+                "run_type.$": "$.run_type",
                 "version.$": "$.version"
             },
             "ItemProcessor": {
@@ -1720,8 +1728,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {
@@ -1950,8 +1958,8 @@
                 "context_index.$": "$$.Map.Item.Index",
                 "context_value.$": "$$.Map.Item.Value",
                 "counter.$": "$.counter",
-                "version.$": "$.version",
-                "run_type.$": "$.run_type"
+                "run_type.$": "$.run_type",
+                "version.$": "$.version"
             },
             "ItemProcessor": {
                 "ProcessorConfig": {

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -817,9 +817,9 @@
                     "Mode": "DISTRIBUTED",
                     "ExecutionType": "STANDARD"
                 },
-                "StartAt": "Batch SubmitJob Priors",
+                "StartAt": "Batch SubmitJob Priors GBPriors",
                 "States": {
-                    "Batch SubmitJob Priors": {
+                    "Batch SubmitJob Priors GBPriors": {
                         "Type": "Task",
                         "Resource": "arn:aws:states:::batch:submitJob.sync",
                         "Parameters": {

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -727,12 +727,12 @@
             "Choices": [
                 {
                     "Variable": "$.run_gbpriors",
-                    "IsPresent": false,
+                    "StringEquals": "false",
                     "Next": "Priors"
                 },
                 {
                     "Variable": "$.run_gbpriors",
-                    "IsPresent": true,
+                    "StringEquals": "true",
                     "Next": "Priors GBPriors"
                 }
             ]
@@ -1710,12 +1710,12 @@
             "Choices": [
                 {
                     "Variable": "$.run_postdiagnostics",
-                    "IsPresent": true,
+                    "StringEquals": "true",
                     "Next": "Postdiagnostics FLPE"
                 },
                 {
                     "Variable": "$.run_postdiagnostics",
-                    "IsPresent": false,
+                    "StringEquals": "false",
                     "Next": "Moi"
                 }
             ]

--- a/workflow-step-function/confluence-sfn-workflow.asl.json
+++ b/workflow-step-function/confluence-sfn-workflow.asl.json
@@ -881,7 +881,7 @@
                     "Key": "continent.json"
                 }
             },
-            "Label": "priors",
+            "Label": "priors_gbpriors",
             "Next": "Hivdi"
         },
         "Hivdi": {


### PR DESCRIPTION
- Allow specification of temporal range for input module
- Provide option to run gbpriors operations in the Priors module
- Update prediagnostics command to support config file S3 bucket retrieval
- Remove tolerated threshold for continent-level modules (except for MetroMan consolidation)
- Define a new `name` tag that will tag the entire workflow for cost tracking